### PR TITLE
feat: unref usetheme to simplify usage

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 const { navigation } = useContent()
-const theme = useTheme()
+const theme = unref(useTheme())
 
 const placeItems = computed(() => {
-  switch (theme.value.footer.position) {
+  switch (theme.footer.position) {
     case 'left':
       return 'place-items-start'
     case 'center':
@@ -16,7 +16,7 @@ const placeItems = computed(() => {
 })
 
 const rowsNumber = computed(() => {
-  return [theme.value.footer.navigation, theme.value.footer.title, theme.value.footer.socials, theme.value.footer.socials?.message.length].reduce((acc, val) => {
+  return [theme.footer.navigation, theme.footer.title, theme.footer.socials, theme.footer.socials?.message.length].reduce((acc, val) => {
     return acc + (val ? 1 : 0)
   }, 0)
 })

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,13 +1,9 @@
 <script lang="ts" setup>
 const { navigation } = useContent()
-const theme = useTheme()
-
-const hasHeader = computed(() => {
-  return theme.value.header
-})
+const theme = unref(useTheme())
 
 const placeItems = computed(() => {
-  switch (theme.value.header.position) {
+  switch (theme.header.position) {
     case 'left':
       return 'place-items-start'
     case 'center':
@@ -22,7 +18,7 @@ const placeItems = computed(() => {
 
 <template>
   <header
-    v-if="hasHeader"
+    v-if="theme.header"
     class="relative"
   >
     <ColorModeSwitch class="absolute top-6 md:top-8" :class="{'right-0' : theme.header.position === 'left'}" />


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/nuxt-themes/alpine/feat/use-theme-unref?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=nuxt-themes&repo=alpine&branch=feat/use-theme-unref">VS Code</a>

<!-- open-in-codesandbox:complete -->


Since `<ThemeOptions>` are not supposed to change dynamically during a component lifecycle, I think it is safe to `unref` them to simplify usage in `<script>` blocks.