### PR TITLE
feat: add image alt to hero

### DIFF
--- a/theme/components/content/Hero.vue
+++ b/theme/components/content/Hero.vue
@@ -4,6 +4,10 @@ defineProps({
     type: String,
     default: null
   },
+  imageAlt: {
+    type: String,
+    default: null
+  },
   layout: {
     type: String,
     default: 'right'
@@ -33,7 +37,7 @@ defineProps({
             : 'lg:ml-14 mt-8'
         "
         :src="image"
-        :alt="image"
+        :alt="imageAlt"
       >
     </div>
   </section>


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/nuxt-themes/alpine/fix/hero/alt?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=nuxt-themes&repo=alpine&branch=fix/hero/alt">VS Code</a>

<!-- open-in-codesandbox:complete -->


