### PR TITLE
feat: added og:image priority for article cover

### DIFF
--- a/layouts/article.vue
+++ b/layouts/article.vue
@@ -26,6 +26,15 @@
 const { page } = useContent()
 const route = useRoute()
 
+const cover = unref(page).cover;
+if(cover) {
+  useHead({
+    meta: [
+      { property: 'og:image', content: cover }
+    ]
+  })
+}
+
 const parentPath = computed(
   () => {
     const pathTabl = route.path.split('/')


### PR DESCRIPTION
This PR sets the `og:image` meta header to the article cover image, if one is set. It overrides the global `alpine.head.image` configuration which is used as a fallback.

Relates to #111 