### PR TITLE
Feat/hero title font

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx nuxi@latest init -t themes/alpine
 1. Clone this repository
 2. Install dependencies using `pnpm install`
 3. Run `pnpm prepare` to generate type stubs.
-4. Use `pnpm dev` to start [playground](./playground) in development mode.
+4. Use `pnpm dev` to start the [playground](./starters/default) in development mode.
 
 ## License
 

--- a/components/content/Hero.vue
+++ b/components/content/Hero.vue
@@ -61,6 +61,7 @@ css({
       '.description': {
         marginTop: '{space.3}',
         fontSize: '{text.xl.fontSize}',
+        fontFamily: 'var(--typography-font-body)',
         lineHeight: '{text.xl.lineHeight}',
       },
       img: {

--- a/components/content/Hero.vue
+++ b/components/content/Hero.vue
@@ -54,6 +54,7 @@ css({
       },
       '.title': {
         fontSize: '{text.4xl.fontSize}',
+        fontFamily: 'var(--typography-font-display)',
         lineHeight: '{text.4xl.lineHeight}',
         fontWeight: '{fontWeight.bold}',
       },


### PR DESCRIPTION
## Problem
Alpine leverages the [@nuxt-themes/typography](https://github.com/nuxt-themes/typography) module, which defines the [available schema](https://github.com/nuxt-themes/typography/blob/main/tokens.config.ts#L119-L133).

My understanding, based on how articles are rendered, is that the `font.display` is meant for headers. However, this token does not get applied to the title on the Hero component. Additionally, the description only receives this font-family style because it is a list. If you remove the list items, it also doesn't get overridden by the token, probably also because it doesn't have an element that the typography module picks up.

## Solution
This is probably because there isn't an `h1` element created as part of the Hero title. Perhaps that should be fixed, however, I noticed that someone could theoretically have a list as the title, where an h1 wouldn't be relevant.

Therefore I decided to add some `fontFamily` css to `Hero.vue` so that anything that is put in the content is appropriately tagged.

Please let me know if there's a different solution that would be better. I'm happy to learn more about this ecosystem 😄 

### Validation

Here is a screenshot of the playground after making the following changes to `.starters/default/tokens.config.ts`:

```typescript
import { defineTheme } from 'pinceau'

export default defineTheme({ 
  typography: {
    font: {
      display: '{font.mono}',
      body: '{font.mono}',
    }
  }
})
```
![Screenshot 2023-07-07 at 16 19 04](https://github.com/nuxt-themes/alpine/assets/132961/2deec2e8-28b1-49be-8180-ee03f4921e8e)

You can clearly see the monospace fonts now instead of the default sans-serif.

### TODO
- [ ] determine whether to update the version in `package.json` as part of this PR (I didn't see it in the contributing guidelines).

# Other Notes
The same sort of thing is happening in Article headers, though in that case there is an `h1` element that is added. I filed an issue with the typography repo to start: https://github.com/nuxt-themes/typography/issues/65 

## Also in this PR
- README.md update for the latest playground location.