### PR TITLE
feat: nuxt-themes#157 handle canonical property in articles

### DIFF
--- a/layouts/article.vue
+++ b/layouts/article.vue
@@ -47,11 +47,19 @@ const alpine = useAppConfig().alpine
 
 const article = ref<HTMLElement | null>(null)
 
-if (page.value && page.value.cover) {
+if (page.value) {
+  const linkArray = []
+  const metaArray = []
+  
+  if (page.value.cover) {
+    metaArray.push({ property: 'og:image', content: page.value.cover })
+  }
+  if (page.value.canonical) {
+    linkArray.push({ rel: 'canonical', href: page.value.canonical })
+  }
   useHead({
-    meta: [
-      { property: 'og:image', content: page.value.cover }
-    ]
+    meta: metaArray,
+    link: linkArray
   })
 }
 


### PR DESCRIPTION
resolves #157

As explained in the above issue, currently there is no support for canonical property on the article page. This PR adds the support for canonical property which is used for SEO purposes.